### PR TITLE
Use `track` for enroll & manage settings actions

### DIFF
--- a/lib/authsignal.ts
+++ b/lib/authsignal.ts
@@ -6,4 +6,8 @@ if (!secret) {
   throw new Error("AUTHSIGNAL_SECRET is undefined");
 }
 
-export const authsignal = new Authsignal({ secret });
+const redirectUrl = process.env.SITE_URL
+  ? `${process.env.SITE_URL}/api/callback`
+  : "http://localhost:3001/api/callback";
+
+export const authsignal = new Authsignal({ secret, redirectUrl });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "supabase-example",
       "version": "0.1.0",
       "dependencies": {
-        "@authsignal/node": "^0.0.29",
+        "@authsignal/node": "^0.0.30",
         "@hapi/iron": "^7.0.0",
         "@supabase/auth-helpers-nextjs": "^0.2.5",
         "@supabase/supabase-js": "^1.35.4",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@authsignal/node": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@authsignal/node/-/node-0.0.29.tgz",
-      "integrity": "sha512-tj2Xfm3bm9w5Wo/03CUvXr8JKS5im943xDZldf53CWt3p2V+iNRjMdR+Gagfn1dVtwmokkFHAUdBkNE0QqWEFQ==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@authsignal/node/-/node-0.0.30.tgz",
+      "integrity": "sha512-zgSuUMVblWP/eIFGkkOtGOL1CrAss1rgwYx+ni8rIS0MV8eLmJfFKNIUPrsZfpDEWVwbUO6GyRjpuM95tojYUA==",
       "dependencies": {
         "axios": "^0.27.2",
         "jsonwebtoken": "^8.5.1"
@@ -3582,9 +3582,9 @@
   },
   "dependencies": {
     "@authsignal/node": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@authsignal/node/-/node-0.0.29.tgz",
-      "integrity": "sha512-tj2Xfm3bm9w5Wo/03CUvXr8JKS5im943xDZldf53CWt3p2V+iNRjMdR+Gagfn1dVtwmokkFHAUdBkNE0QqWEFQ==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@authsignal/node/-/node-0.0.30.tgz",
+      "integrity": "sha512-zgSuUMVblWP/eIFGkkOtGOL1CrAss1rgwYx+ni8rIS0MV8eLmJfFKNIUPrsZfpDEWVwbUO6GyRjpuM95tojYUA==",
       "requires": {
         "axios": "^0.27.2",
         "jsonwebtoken": "^8.5.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@authsignal/node": "^0.0.29",
+    "@authsignal/node": "^0.0.30",
     "@hapi/iron": "^7.0.0",
     "@supabase/auth-helpers-nextjs": "^0.2.5",
     "@supabase/supabase-js": "^1.35.4",

--- a/pages/api/mfa.ts
+++ b/pages/api/mfa.ts
@@ -12,12 +12,11 @@ export default withApiAuth(async function mfa(
 
   const { user } = await getUser({ req, res });
 
-  const { deviceId, isEnrolled } = req.body;
+  const { isEnrolled } = req.body;
 
   const { url: mfaUrl } = await authsignal.track({
-    action: isEnrolled ? "manage-settings" : "enroll",
+    action: isEnrolled ? "manageSettings" : "enroll",
     userId: user.id,
-    deviceId,
     redirectToSettings: isEnrolled,
   });
 

--- a/pages/api/mfa.ts
+++ b/pages/api/mfa.ts
@@ -1,0 +1,25 @@
+import { getUser, withApiAuth } from "@supabase/auth-helpers-nextjs";
+import { NextApiRequest, NextApiResponse } from "next";
+import { authsignal } from "../../lib/authsignal";
+
+export default withApiAuth(async function mfa(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).send({ message: "Only POST requests allowed" });
+  }
+
+  const { user } = await getUser({ req, res });
+
+  const { deviceId, isEnrolled } = req.body;
+
+  const { url: mfaUrl } = await authsignal.track({
+    action: isEnrolled ? "manage-settings" : "enroll",
+    userId: user.id,
+    deviceId,
+    redirectToSettings: isEnrolled,
+  });
+
+  res.send({ mfaUrl });
+});

--- a/pages/api/sign-in.ts
+++ b/pages/api/sign-in.ts
@@ -11,7 +11,7 @@ export default async function signIn(
     return res.status(405).send({ message: "Only POST requests allowed" });
   }
 
-  const { email, password, deviceId } = req.body;
+  const { email, password } = req.body;
 
   const { data, error } = await supabaseClient.auth.api.signInWithEmail(
     email,
@@ -25,7 +25,6 @@ export default async function signIn(
   const { state, url: mfaUrl } = await authsignal.track({
     action: "signIn",
     userId: data.user.id,
-    deviceId,
   });
 
   if (state === "CHALLENGE_REQUIRED") {

--- a/pages/api/sign-up.ts
+++ b/pages/api/sign-up.ts
@@ -15,12 +15,11 @@ export default async function signUp(
   );
 
   if (error || !isSession(data)) {
-    return res.send({ error });
+    res.send({ error });
+  } else {
+    setAuthCookie(data, res);
+    res.send({ data });
   }
-
-  setAuthCookie(data, res);
-
-  res.redirect("/");
 }
 
 const isSession = (data: any): data is Session => !!data?.access_token;

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -1,9 +1,36 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 
 export default function SignInPage() {
+  const router = useRouter();
+
   return (
     <main>
-      <form method="POST" action="/api/sign-in">
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+
+          const target = e.target as typeof e.target & {
+            email: { value: string };
+            password: { value: string };
+          };
+
+          const email = target.email.value;
+          const password = target.password.value;
+
+          const { state, mfaUrl } = await fetch("/api/sign-in", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, password }),
+          }).then((res) => res.json());
+
+          if (state === "CHALLENGE_REQUIRED") {
+            window.location.href = mfaUrl;
+          } else {
+            router.push("/");
+          }
+        }}
+      >
         <label htmlFor="email">Email</label>
         <input id="email" type="email" name="email" required />
         <label htmlFor="password">Password</label>

--- a/pages/sign-up.tsx
+++ b/pages/sign-up.tsx
@@ -1,9 +1,32 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 
 export default function SignUpPage() {
+  const router = useRouter();
+
   return (
     <main>
-      <form method="POST" action="/api/sign-up">
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+
+          const target = e.target as typeof e.target & {
+            email: { value: string };
+            password: { value: string };
+          };
+
+          const email = target.email.value;
+          const password = target.password.value;
+
+          await fetch("/api/sign-up", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, password }),
+          }).then((res) => res.json());
+
+          router.push("/");
+        }}
+      >
         <label htmlFor="email">Email</label>
         <input id="email" type="email" name="email" required />
         <label htmlFor="password">Password</label>


### PR DESCRIPTION
- Use `track` for enroll & manage settings actions, so an audit trail for them will appear in the Authsignal Portal
- Pass the `redirectUrl` once in the Authsignal node client constructor since it's always the same